### PR TITLE
Doco improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-gwt-maven-springboot-archetype
-==============================
+# gwt-maven-springboot-archetype
 
-This project contains a Maven archetype for modular GWT projects using Spring Boot. The repo is based on the implementation of Thomas Broyer's [gwt-maven-archetypes](https://github.com/tbroyer/gwt-maven-archetypes).
+This project contains a Maven archetype for modular GWT projects using Spring Boot. The repo is based on the
+implementation of Thomas Broyer's [gwt-maven-archetypes](https://github.com/tbroyer/gwt-maven-archetypes).
 
-If you are looking for the original archetype creator or would prefer another backend/implementation, please visit:  [gwt-maven-archetypes](https://github.com/tbroyer/gwt-maven-archetypes).
+If you are looking for the original archetype creator or would prefer another backend/implementation, please visit:
+[gwt-maven-archetypes](https://github.com/tbroyer/gwt-maven-archetypes).
 
-How to use
-----------
+## How to use
 
 ### Generate a project
 
-    mvn archetype:generate \
-       -DarchetypeGroupId=com.github.nalukit.archetype \
-       -DarchetypeVersion=LATEST \
-       -DarchetypeArtifactId=<artifactId>
+```shell
+mvn archetype:generate -DarchetypeGroupId=com.github.nalukit.archetype -DarchetypeVersion=LATEST -DarchetypeArtifactId=<artifactId>
+```
 
 where the available `<artifactIds>` is:
 
@@ -22,9 +21,12 @@ where the available `<artifactIds>` is:
 
 This should use the latest release from the Central Repository.
 
+> 📝 Maven 2.2 or later is required.
+
 #### clean-modular-springboot-webapp
 
-Generates a clean Spring Boot multi Maven module project without any example code. If you need a clean approach, this is the best way to start.
+Generates a clean Spring Boot multi Maven module project without any example code. If you need a clean approach, this is
+the best way to start.
 
 The generated project will use the following version:
 
@@ -34,7 +36,8 @@ The generated project will use the following version:
 
 #### modular-springboot-webapp
 
-Generates a Spring Boot multi Maven module project with any example code. The example is similar to the one from the GWT project.
+Generates a Spring Boot multi Maven module project with any example code. The example is similar to the one from the GWT
+project.
 
 The generated project will use the following version:
 
@@ -42,45 +45,58 @@ The generated project will use the following version:
 * GWT 2.11.0
 * Spring Boot 3.2.5
 
-### Local generation 
-
-Alternatively, and/or if you want to hack on / contribute to the archetypes,
-you can clone and install the project locally:
-
-    git clone https://github.com/NaluKit/gwt-maven-springboot-archetype
-    cd gwt-maven-springboot-archetype && mvn clean compile
-
-You'll then use the `mvn archetype:generate` command from above, except for the
-`-DarchetypeVersion` argument which you'll replace with `HEAD-SNAPSHOT`.
-
-
 ### Start the development mode
 
 Change directory to your generated project and issue the following commands:
 
 1. In one terminal window: `mvn gwt:codeserver -pl *-client -am`
-2. In another terminal window: `mvn spring-boot:run -pl *-server -am` 
+1. In another terminal window: `mvn spring-boot:run -pl *-server -am` 
 
-After a `mvn clean compile` you have to wait until you see this line 'The code server is ready at http://127.0.0.1:9876/' before starting the Spring Boot server.
+> 📝 The `-pl` and `-am` are not strictly necessary, they just tell Maven not to build the client module when you're
+dealing with the server one, and vice versa.
 
-Note that the `-pl` and `-am` are not strictly necessary, they just tell Maven not to
-build the client module when you're dealing with the server one, and vice versa.
+Once both are server are running, enter http://localhost:8080 in a browser window.
 
-In case you will debug the server code and create a running configuration in your preferred IDE, make sure, to start the code server (wait until the url with 9876 at the end appears) before the Spring Boot Service.
+> 📝 Both servers are running when the code server outputs `The code server is ready at http://127.0.0.1:9876/`
+and the Spring Boot server outputs `Started Application in xxx seconds`.
 
-Once both are server are running, enter `http://localhost:8080` in a browser window.
+## Build a release
 
-Compatibility
--------------
+After you have generated your project from the above steps, you can create a release build and test it works.
 
-To use variable interpolation in parameters during `mvn archetype:generate`,
-you need at least version 2.2 of the maven-archetype-plugin. Archetypes use
-`${module.toLowerCase()}` as the default value for the `module-short-name`
-parameter, so if you don't use version 2.2 or above of the
-maven-archetype-plugin, make sure you provide a value and do not use the
-default one for that parameter. You can also make sure you use version 2.2 of
-the plugin by using `mvn
-org.apache.maven.plugins:maven-archetype-plugin:2.2:generate` instead of `mvn
-archetype:generate`. It should be noted that variable interpolation also does
-not work in M2Eclipse's wizard, despite using recent versions of Maven thus
-(probably) a recent-enough version of the maven-archetype-plugin.
+Change directory to your generated project and issue the following commands:
+
+1. `mvn clean package`
+1. `cd *-server/target`
+1. `java -jar myapp.war`
+
+> 📝 Replace `myapp.war` with the name of your war file.
+
+Open http://localhost:8080 in a browser window to test your release build.
+
+## Contributing
+
+If you want to hack on / contribute to the archetypes, you can:
+
+```shell
+git clone https://github.com/NaluKit/gwt-maven-springboot-archetype
+cd gwt-maven-springboot-archetype
+```
+Make your changes, and run:
+
+```shell
+mvn clean verify
+```
+
+This will generate sample apps that can be found in both the `clean-modular-springboot-webapp` and
+`modular-springboot-webapp` directories, in the `target/test-classes/projects/basic-webapp/project/basic-webapp`
+directory.
+
+You can also install your modified version of the project locally:
+
+```shell
+mvn clean install
+```
+
+Then use the `mvn archetype:generate` command from above, except for the `-DarchetypeVersion` argument which you'll
+replace with `HEAD-SNAPSHOT`.


### PR DESCRIPTION
- Added `Build a release` section.
- Moved `Local generation` section to bottom and renamed it `Contributing`.
- Improved Contributing doco to show where verify project is, and how to maven install if needed.
- Removed old "Compatibility" section and added note to use Maven 2.2 or later.
- Removed command `\` and `&` as they don't work on Windows systems.
- Tidied up and made the line wrap width the standard 120 characters, and headings a constant hash.