### PR TITLE
Switch client source level to 17.

### DIFF
--- a/clean-modular-springboot-webapp/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
+++ b/clean-modular-springboot-webapp/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
@@ -13,7 +13,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <!-- The server can use Java 17 syntax -->
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>

--- a/clean-modular-springboot-webapp/src/main/resources/archetype-resources/pom.xml
+++ b/clean-modular-springboot-webapp/src/main/resources/archetype-resources/pom.xml
@@ -66,7 +66,7 @@
           <version>1.1.0</version>
           <extensions>true</extensions>
           <configuration>
-            <sourceLevel>11</sourceLevel>
+            <sourceLevel>17</sourceLevel>
             <failOnError>true</failOnError>
           </configuration>
         </plugin>

--- a/clean-modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-server/pom.xml
+++ b/clean-modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-server/pom.xml
@@ -12,7 +12,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <!-- The server can use Java 17 syntax -->
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>

--- a/clean-modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/pom.xml
+++ b/clean-modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/pom.xml
@@ -66,7 +66,7 @@
           <version>1.1.0</version>
           <extensions>true</extensions>
           <configuration>
-            <sourceLevel>11</sourceLevel>
+            <sourceLevel>17</sourceLevel>
             <failOnError>true</failOnError>
           </configuration>
         </plugin>

--- a/modular-springboot-webapp/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
+++ b/modular-springboot-webapp/src/main/resources/archetype-resources/__rootArtifactId__-server/pom.xml
@@ -13,7 +13,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <!-- The server can use Java 17 syntax -->
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>

--- a/modular-springboot-webapp/src/main/resources/archetype-resources/pom.xml
+++ b/modular-springboot-webapp/src/main/resources/archetype-resources/pom.xml
@@ -71,7 +71,7 @@
           <version>1.1.0</version>
           <extensions>true</extensions>
           <configuration>
-            <sourceLevel>11</sourceLevel>
+            <sourceLevel>17</sourceLevel>
             <failOnError>true</failOnError>
           </configuration>
         </plugin>

--- a/modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-server/pom.xml
+++ b/modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/basic-webapp-server/pom.xml
@@ -12,7 +12,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <!-- The server can use Java 17 syntax -->
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
   </properties>

--- a/modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/pom.xml
+++ b/modular-springboot-webapp/src/test/resources/projects/basic-webapp/reference/pom.xml
@@ -71,7 +71,7 @@
           <version>1.1.0</version>
           <extensions>true</extensions>
           <configuration>
-            <sourceLevel>11</sourceLevel>
+            <sourceLevel>17</sourceLevel>
             <failOnError>true</failOnError>
           </configuration>
         </plugin>


### PR DESCRIPTION
GWT now supports Java 17 syntax.

Testing:
- Ran `mvn clean verify`.  Passed.
- Ran `mvn clean install`, created an app with `HEAD-SNAPSHOT`, and ran it.  Worked.